### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  statuses: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IT-Hock/sentry-yt/security/code-scanning/1](https://github.com/IT-Hock/sentry-yt/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow to define the minimum required permissions. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for basic repository access (e.g., checking out the code).
- `statuses: write` for updating commit statuses (if applicable).
- `id-token: write` for the `codecov/codecov-action` step, which may require an OpenID Connect (OIDC) token for authentication.

The `permissions` block should be added at the root level to apply to all jobs in the workflow. If specific jobs require different permissions, job-specific `permissions` blocks can be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
